### PR TITLE
sysparam_query cannot be null/empty fix (service-now.js)

### DIFF
--- a/service-now.js
+++ b/service-now.js
@@ -107,7 +107,8 @@ class ServiceNow {
             auth: this.auth,
             qs: {
                 JSONv2: '',
-                sysparm_query: this.query,
+                //sysparm_query: this.query, --> this did'nt quite work for me, give me an error stating that 'sysparam_query cannot be null/empty',  so I replaced it with the following code:
+                sysparm_query: this.qs.sysparm_query, //this works perfectly now
                 displayvariables: 'true',
                 displayvalues: 'true',
                 sysparm_action: 'update'


### PR DESCRIPTION
First of all, **awesome work by @eliash91!** I've just made some very minor changes..
Ran into an issue while trying to update a servicenow ticket (in my case 'incident'). 
Kept getting an error response that 'sysparam_query cannot be null/empty' (paraphrasing). 

So made a minor adjustment to line number 110 (file: service-now.js). Changed it to `sysparm_query: this.qs.sysparm_query` and that works perfectly for me. **Thanks once again to eliash91..**